### PR TITLE
chore(github): standardize issue/PR templates and contribution flow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default owners — every PR auto-requests review from this team.
+# Replace @Wizwam/platform-maintainers with the actual GitHub team handle.
+*                                  @Wizwam/platform-maintainers
+
+# Path-scoped owners (uncomment and edit as the team grows):
+# /admin/                          @Wizwam/admin-owners
+# /docs/                           @Wizwam/docs
+# /.github/                        @Wizwam/platform-maintainers
+# /lib/                            @Wizwam/platform-maintainers

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+---
+name: Bug report
+about: Something is broken or behaves incorrectly
+title: "fix: <short description>"
+labels: ["bug", "triage"]
+assignees: []
+---
+
+## Severity
+
+- [ ] **P0** — production down, data loss, security exposure (page on-call now)
+- [ ] **P1** — core feature broken, no workaround, blocking users/agents
+- [ ] **P2** — degraded but workaround exists
+- [ ] **P3** — minor / cosmetic
+
+## Affected users / agents
+
+<!-- Who feels this? Humans (which role), agents (which one), all platform tenants, single tenant, etc. -->
+
+## What happened
+
+<!-- One or two sentences. The observable symptom, not the suspected cause. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behaviour
+
+<!-- What should have happened instead. -->
+
+## Environment
+
+- Service / app:
+- Version / commit SHA:
+- Host (browser, OS, deploy target):
+
+## Logs / screenshots
+
+```text
+<paste relevant logs here>
+```
+
+## Suspected cause (optional)
+
+<!-- Leave blank if unknown. Don't guess. -->

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,19 @@
+---
+name: Chore
+about: Maintenance work — deps, refactor, docs, tooling, CI
+title: "chore: <short description>"
+labels: ["chore"]
+assignees: []
+---
+
+## What
+
+<!-- The task. -->
+
+## Why now
+
+<!-- Why this is worth doing now rather than later. -->
+
+## Done when
+
+- [ ]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Wizwam Trust Charter
+    url: https://github.com/Wizwam/charter
+    about: Governance, ten commandments, and how decisions get made.
+  - name: Security disclosure
+    url: mailto:security@wizwam.com
+    about: Report a vulnerability privately. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,39 @@
+---
+name: Feature request
+about: Propose new behaviour or capability
+title: "feat: <short description>"
+labels: ["feature", "triage"]
+assignees: []
+---
+
+## User story
+
+> As a **[role — human user / operator / agent / tenant]**,
+> I want **[capability]**,
+> so that **[outcome / value]**.
+
+## Problem
+
+<!-- What user/operator/agent need is unmet today? Who feels the pain? -->
+
+## Proposed solution
+
+<!-- The smallest change that solves the problem. -->
+
+## Alternatives considered
+
+<!-- Other options and why they were rejected. Leave blank if none. -->
+
+## Acceptance criteria
+
+- [ ]
+- [ ]
+- [ ]
+
+## Out of scope
+
+<!-- Things this issue explicitly does NOT cover, to prevent scope creep. -->
+
+## Charter / policy notes (optional)
+
+<!-- Reference any TRUST_CHARTER or ten-commandments rule this touches. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,56 @@
+<!-- markdownlint-disable MD041 -->
+<!--
+Title format: Conventional Commits
+  feat(scope): add X
+  fix(scope): handle Y
+  chore(scope): bump Z
+  docs(scope): clarify W
+-->
+
+## Summary
+
+<!-- 1–3 sentences: what changes and why. The "why" matters more than the "what". -->
+
+## Linked issue
+
+Closes #
+
+## Type of change
+
+- [ ] `feat` — new behaviour
+- [ ] `fix` — bug fix
+- [ ] `chore` — maintenance / deps / tooling
+- [ ] `docs` — documentation only
+- [ ] `refactor` — internal change, no behaviour change
+- [ ] `test` — tests only
+
+## How to test
+
+<!-- Concrete steps a reviewer can run. Include URLs, commands, or screenshots. -->
+
+1.
+2.
+
+## Screenshots / recordings (UI changes)
+
+<!-- Drag images in. Required for any visible UI change. -->
+
+## Risk & rollback
+
+- **Blast radius:** local / single service / cross-service / data migration
+- **Rollback plan:** revert this PR / requires data fix / forward-fix only
+- **Breaking change?** No / Yes — describe the API/behaviour break and the migration path
+- **Performance impact:** None expected / measured (attach numbers) / unknown — needs review
+
+## Checklist
+
+- [ ] Title follows Conventional Commits
+- [ ] Linked issue references with `Closes #`
+- [ ] Tests added or updated (or reason given for none)
+- [ ] Docs updated (README, CLAUDE.md, AGENTS.md, runbooks) if behaviour changed
+- [ ] No secrets, tokens, or `.env` files committed
+- [ ] CI is green
+
+## Charter notes (if applicable)
+
+<!-- Cite any TRUST_CHARTER section this implements or is governed by. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/Toronto
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+    labels:
+      - chore
+      - dependencies
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/Toronto
+    commit-message:
+      prefix: "chore(ci)"
+      include: scope
+    labels:
+      - chore
+      - ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to Wizwam
+
+This file documents the **universal workflow** used across every Wizwam repo. Every repo under [github.com/Wizwam](https://github.com/orgs/Wizwam/repositories) follows the same flow so contributors — human or AI (Claude Code, GitHub Copilot, OpenAI Codex) — can move between repos without relearning conventions.
+
+## The flow
+
+```
+Issue (#123)  →  Branch (feat/123-slug)  →  Commits  →  PR  →  Review  →  Squash-merge  →  Issue auto-closes
+```
+
+Three layers, three artefacts:
+
+| Layer | What | Where |
+|---|---|---|
+| **Intent** | What we want to build / fix | GitHub Issue (uses an issue template) |
+| **Work** | The diff in progress | A branch, named after the issue |
+| **Delivery** | Proposed change for review | Pull Request (uses the PR template) |
+
+## 1. Open an issue first
+
+Every change starts with an issue. Use the templates:
+
+- **Bug** → `bug_report.md` (title prefix `fix:`)
+- **Feature** → `feature_request.md` (title prefix `feat:`)
+- **Maintenance** → `chore.md` (title prefix `chore:`)
+
+Only skip the issue for one-line typo fixes.
+
+## 2. Branch naming
+
+```
+<type>/<issue-#>-<short-slug>
+```
+
+Examples:
+
+- `feat/42-voicedna-export`
+- `fix/87-approval-timeout`
+- `chore/bump-anthropic-sdk`
+- `docs/contributing-flow`
+
+`<type>` matches Conventional Commits: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`.
+
+## 3. Commits — Conventional Commits
+
+```
+<type>(<scope>): <imperative summary>
+
+<optional body explaining why>
+
+<optional footer, e.g. Closes #42>
+```
+
+Examples:
+
+```
+feat(voicedna): add CSV export endpoint
+fix(approvals): handle 30s broker timeout
+chore(deps): bump @anthropic-ai/sdk to 0.39
+docs(readme): clarify install steps
+```
+
+Why: GitHub renders these nicely, every modern AI tool understands them, and changelog generators can read them automatically.
+
+## 4. Pull Request
+
+- Use the `PULL_REQUEST_TEMPLATE.md` — it auto-loads.
+- PR title = the squash-merge commit message → must follow Conventional Commits.
+- Body must include `Closes #<issue>` so the issue auto-closes on merge.
+- CI must be green before merge.
+- At least one approving review from a CODEOWNER.
+
+## 5. Merging
+
+- **Default:** squash-merge. Keeps `main` history linear and readable.
+- **Exception:** long-lived feature branches with meaningful commit history may use a merge commit, by maintainer decision.
+- After merge: branch is auto-deleted, issue auto-closes.
+
+## Labels (standard set)
+
+| Label | Meaning |
+|---|---|
+| `bug` | Something is broken |
+| `feature` | New capability |
+| `chore` | Maintenance |
+| `docs` | Documentation only |
+| `triage` | Needs maintainer review |
+| `good-first-issue` | Onboarding-friendly |
+| `blocked` | Waiting on something external |
+| `security` | Security-relevant — handle privately first |
+
+## Working with AI agents
+
+This repo includes both `CLAUDE.md` (Claude Code instructions) and `AGENTS.md` (OpenAI Codex / Copilot instructions). When you ask any agent to make a change, ask it to:
+
+1. Open or reference an issue.
+2. Create a branch using the convention above.
+3. Use Conventional Commits.
+4. Open a PR using the template.
+
+That way the same workflow applies regardless of which tool produced the diff.
+
+## Security
+
+Do **not** open public issues for vulnerabilities. Email `security@wizwam.com`. See `SECURITY.md` for the full policy.
+
+## Governance
+
+Substantial decisions (architecture, data handling, third-party integrations) reference the [Wizwam Trust Charter](https://github.com/Wizwam/charter). Cite the relevant section in the PR description when applicable.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Email **security@wizwam.com** with:
+
+- A description of the issue
+- Steps to reproduce
+- The affected version / commit SHA
+- Your assessment of impact
+
+Please do **not** open a public GitHub issue for security reports.
+
+## What to expect
+
+- Acknowledgement within 3 business days.
+- A coordinated disclosure timeline agreed with the reporter.
+- Credit in the release notes (unless you prefer to remain anonymous).
+
+## Supported versions
+
+Only the `main` branch and the most recent tagged release receive security fixes.


### PR DESCRIPTION
## Summary

First PR after transferring this repo from `lukejmorrison/code2md` → `Wizwam/code2md`. Adopts the universal Wizwam contribution workflow so code2md follows the same Issue → Branch → PR → squash-merge process as `apps.wizwam.com` (see [Wizwam/apps.wizwam.com#1](https://github.com/Wizwam/apps.wizwam.com/pull/1) for the reference).

## Linked issue

(no pre-existing issue — process bootstrap)

## Type of change

- [x] `chore` — tooling / process

## How to test

1. After merge, visit https://github.com/Wizwam/code2md/issues/new/choose — bug / feature / chore templates should appear.
2. Open a draft PR — the PR template should auto-populate.
3. Confirm Dependabot opens its first weekly batch on the next Monday.

## Risk & rollback

- **Blast radius:** local — pure additions; no edits to existing source, build, or `workflows/publish.yml`
- **Rollback plan:** revert this PR
- **Breaking change?** No
- **Performance impact:** None

## Notes for reviewer

- Pre-existing local work (`AGENTS.md`, `LOCAL-DEVELOPMENT.md`, `docs/`, modified `package-lock.json`) was intentionally left out — it ships as a separate PR using the new flow.
- `CODEOWNERS` placeholder `@Wizwam/platform-maintainers` to be replaced with the real team handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)